### PR TITLE
Release Process pt2

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -8,12 +8,11 @@ on:
       release_version:
         description: 'Release version (X.Y.Z)'
 
-env:
-  VERSION_NAME: "${{ github.events.inputs.release_version }}"
-  VERSION_CODE: "${{ github.run_number }}"
-  BRANCH: "release/${{ env.VERSION_NAME }}"
-
 jobs:
+  env:
+    VERSION_NAME: "${{ github.events.inputs.release_version }}"
+    VERSION_CODE: "${{ github.run_number }}"
+    BRANCH: "release/${{ env.VERSION_NAME }}"
 
   # Create a release branch to work from
   prepare_branch:


### PR DESCRIPTION
Github Actions requires the release yml to be on master before it can be tested

This PR addresses a syntax error in env being at the top level instead of under the jobs section.