### PR TITLE
Release Process pt3

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -8,11 +8,12 @@ on:
       release_version:
         description: 'Release version (X.Y.Z)'
 
+env:
+  VERSION_NAME: "${{ github.events.inputs.release_version }}"
+  VERSION_CODE: "${{ github.run_number }}"
+  BRANCH: "release/${{ github.events.inputs.release_version }}"
+
 jobs:
-  env:
-    VERSION_NAME: "${{ github.events.inputs.release_version }}"
-    VERSION_CODE: "${{ github.run_number }}"
-    BRANCH: "release/${{ env.VERSION_NAME }}"
 
   # Create a release branch to work from
   prepare_branch:


### PR DESCRIPTION
Github Actions requires the release yml to be on master before it can be tested

This PR is still trying to address a syntax error in workflow-level env variables.