### PR TITLE
Release Process pt7

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Commit Changes
         run: |
           git add CHANGELOG.md
-          git commit -m "Prepare release ${{ env.VERSION_NAME }}(${{ env.VERSION_CODE }})"
+          git commit -m "Prepare release ${{ env.VERSION_NAME }}(${{ env.VERSION_CODE }})" || echo "Nothing to commit, Ignoring"
           git push origin ${{ env.BRANCH }}
 
   # Test debug and release, run coverage against debug
@@ -75,7 +75,7 @@ jobs:
       - name: Commit Changes
         run: |
           git add .github/badges/coverage.json
-          git commit -m "Update coverage badge"
+          git commit -m "Update coverage badge" || echo "Nothing to commit, Ignoring"
           git push origin ${{ env.BRANCH }}
 
       - name: Archive Reports

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Vessel
-todo: auto-gen github badge from release workflow (build status)
 ![Release](https://img.shields.io/github/v/release/textnow/vessel?include_prereleases)
 ![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgithub.com%2Ftextnow%2Fvessel%2Ftree%2Fmaster%2F.github%2Fbadges%2Fcoverage.json&style=flat)
 ![License](https://img.shields.io/github/license/textnow/vessel)


### PR DESCRIPTION
Github Actions requires the release yml to be on master before it can be tested

Prevent git commit from failing if no files have changed.