### PR TITLE
Release Process pt8

### DIFF
--- a/buildSrc/src/main/kotlin/Publishing.kt
+++ b/buildSrc/src/main/kotlin/Publishing.kt
@@ -33,5 +33,5 @@ object GithubPackageRepository {
 
     private val env = System.getenv()
     val username: String = env.getOrDefault("GHR_USER", "")
-    val password: String = env.getOrDefault("GHR_PASSWORD", "")
+    val password: String = env.getOrDefault("GHR_PWD", "")
 }


### PR DESCRIPTION
Github Actions requires the release yml to be on master before it can be tested

android_release.yml and Publishing.kt didn't use the same env vars.