### PR TITLE
[VSL-25] add new replace overload + deprecate old replace method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [VSL-25](https://github.com/textnow/vessel/issues/25) Added new `replace` method overload to support passing in the old data model type
+- [VSL-25](https://github.com/textnow/vessel/issues/25) Added new `replace` method overload to support passing in the old data model class type
 
 ### Deprecated
 
-- [VSL-25](https://github.com/textnow/vessel/issues/25) Deprecated `replace` method overload that required the old data model to be passed in
+- [VSL-25](https://github.com/textnow/vessel/issues/25) Deprecated `replace` method overload that required the old data model object to be passed in
 
 ## [0.1.1] - 2021-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [VSL-25](https://github.com/textnow/vessel/issues/25) Added new `replace` method overload to support passing in the old data model type
+
+### Deprecated
+
+- [VSL-25](https://github.com/textnow/vessel/issues/25) Deprecated `replace` method overload that required the old data model to be passed in
+
 ## [0.1.1] - 2021-09-10
 
 ### Changed

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/NoOpVessel.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/NoOpVessel.kt
@@ -46,6 +46,7 @@ class NoOpVessel : Vessel {
     override suspend fun <T : Any> set(value: T) { /* no-op */ }
     override suspend fun <T : Any> delete(type: KClass<T>) { /* no-op */ }
     override suspend fun <OLD : Any, NEW : Any> replace(old: OLD, new: NEW) { /* no-op */ }
+    override suspend fun <OLD : Any, NEW : Any> replace(oldType: KClass<OLD>, new: NEW) { /* no-op */ }
     override fun clear() { /* no-op */ }
     override fun <T : Any> flow(type: KClass<T>): Flow<T?> = emptyFlow()
     override fun <T : Any> livedata(type: KClass<T>): LiveData<T?> = liveData {  }

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/Vessel.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/Vessel.kt
@@ -122,8 +122,8 @@ interface Vessel {
      * @param new data model to add
      */
     @Deprecated(
-        message = "replacing by passing in objects will be removed in a future version in favour of using class types",
-        replaceWith = ReplaceWith("replace(old::class, new::class)"),
+        message = "replacing by passing in an object will be removed in a future version in favour of using class type",
+        replaceWith = ReplaceWith("replace(oldType = old::class, new = new)"),
     )
     suspend fun <OLD : Any, NEW : Any> replace(old: OLD, new: NEW)
 

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/Vessel.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/Vessel.kt
@@ -121,7 +121,19 @@ interface Vessel {
      * @param old data model to remove
      * @param new data model to add
      */
+    @Deprecated(
+        message = "replacing by passing in objects will be removed in a future version in favour of using class types",
+        replaceWith = ReplaceWith("replace(old::class, new::class)"),
+    )
     suspend fun <OLD : Any, NEW : Any> replace(old: OLD, new: NEW)
+
+    /**
+     * Replace one data with another, in a suspending transaction.
+     *
+     * @param oldType of data model to remove
+     * @param new data model to add
+     */
+    suspend fun <OLD : Any, NEW : Any> replace(oldType: KClass<OLD>, new: NEW)
 
     /**
      * Clear the database.

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselDao.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselDao.kt
@@ -122,7 +122,7 @@ abstract class VesselDao {
     /**
      * Replace an old entity with a new entity inside a single suspending transaction.
      *
-     * @param old entity to remove
+     * @param oldType entity to remove
      * @param new entity to add
      */
     @Transaction

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselDao.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselDao.kt
@@ -126,9 +126,9 @@ abstract class VesselDao {
      * @param new entity to add
      */
     @Transaction
-    open suspend fun replace(old: VesselEntity, new: VesselEntity) {
+    open suspend fun replace(oldType: String, new: VesselEntity) {
         set(new)
-        delete(old.type)
+        delete(oldType)
     }
 
     // endregion

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
@@ -263,8 +263,8 @@ class VesselImpl(
      * @param new data model to add
      */
     @Deprecated(
-        message = "replacing by passing in objects will be removed in a future version in favour of using class types",
-        replaceWith = ReplaceWith("replace(old::class, new::class)"),
+        message = "replacing by passing in an object will be removed in a future version in favour of using class type",
+        replaceWith = ReplaceWith("replace(oldType = old::class, new = new)"),
     )
     override suspend fun <OLD : Any, NEW : Any> replace(old: OLD, new: NEW) {
         replace(old::class, new)

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
@@ -262,21 +262,37 @@ class VesselImpl(
      * @param old data model to remove
      * @param new data model to add
      */
+    @Deprecated(
+        message = "replacing by passing in objects will be removed in a future version in favour of using class types",
+        replaceWith = ReplaceWith("replace(old::class, new::class)"),
+    )
     override suspend fun <OLD : Any, NEW : Any> replace(old: OLD, new: NEW) {
+        replace(old::class, new)
+    }
+
+    /**
+     * Replace one data with another, in a suspending transaction.
+     *
+     * @param oldType of data model to remove
+     * @param new data model to add
+     */
+    override suspend fun <OLD : Any, NEW : Any> replace(
+        oldType: KClass<OLD>,
+        new: NEW
+    ) {
         check(!closeWasCalled) { "Vessel($name:${hashCode()}) was already closed." }
-        val oldName = typeNameOf(old)
         val newName = typeNameOf(new)
-        if (oldName == newName) {
-            set(new)
-        } else {
-            dao.replace(
-                old = VesselEntity(
-                    type = oldName,
-                    data = toJson(old)),
-                new = VesselEntity(
-                    type = newName,
-                    data = toJson(new))
-            )
+        oldType.qualifiedName?.let { oldName ->
+            if (oldName == newName) {
+                set(new)
+            } else {
+                dao.replace(
+                    oldType = oldName,
+                    new = VesselEntity(
+                        type = newName,
+                        data = toJson(new))
+                )
+            }
         }
     }
 

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselImplTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselImplTest.kt
@@ -141,7 +141,7 @@ class VesselImplTest: BaseVesselTest() {
             name = firstSimple.name,
             number = firstSimple.number?.toDouble()
         )
-        vessel.replace(oldType = firstSimple::class, new = replacement)
+        vessel.replace(old = firstSimple, new = replacement)
         assertThat(vessel.get(SimpleData::class)).isNull()
         assertThat(vessel.get(SimpleDataV2::class)?.number).isEqualTo(replacement.number)
     }

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselImplTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselImplTest.kt
@@ -144,6 +144,10 @@ class VesselImplTest: BaseVesselTest() {
         vessel.replace(old = firstSimple, new = replacement)
         assertThat(vessel.get(SimpleData::class)).isNull()
         assertThat(vessel.get(SimpleDataV2::class)?.number).isEqualTo(replacement.number)
+
+        vessel.replace(oldType = replacement::class, new = firstSimple)
+        assertThat(vessel.get(SimpleDataV2::class)).isNull()
+        assertThat(vessel.get(SimpleData::class)?.number).isEqualTo(firstSimple.number)
     }
 
     fun `writing the same data type replaces the value`() = runBlocking {

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselImplTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselImplTest.kt
@@ -141,7 +141,7 @@ class VesselImplTest: BaseVesselTest() {
             name = firstSimple.name,
             number = firstSimple.number?.toDouble()
         )
-        vessel.replace(old = firstSimple, new = replacement)
+        vessel.replace(oldType = firstSimple::class, new = replacement)
         assertThat(vessel.get(SimpleData::class)).isNull()
         assertThat(vessel.get(SimpleDataV2::class)?.number).isEqualTo(replacement.number)
     }


### PR DESCRIPTION
Fixes [VSL-25](https://github.com/textnow/vessel/issues/25).

**Changes:**
- Added method overload for replace to accept the old type to be replaced, and the new data object to place in Vessel
- Deprecated replace method that accepts two data models
- Update the DAO to accept a type string and an object for replace
- Updated unit test to use the new replace function

