### PR TITLE
[VSL-3] add optional caching mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [VSL-3](https://github.com/textnow/vessel/issues/3) Added the ability to enable caching for Vessel
+
 ## [0.1.1] - 2021-09-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ val vessel = VesselImpl(
         onOpen = { Log.d(TAG, "Database opened") },
         onClosed = { Log.d(TAG, "Database closed") },
         onDestructiveMigration = { Log.d(TAG, "Destructive migration") }
-    )
+    ),
+    cache = DefaultCache()
 )
 ```
 
@@ -129,6 +130,7 @@ val vessel = VesselImpl(
 | inMemory | When false (default) it will use a SQL database.  When true (for example, in tests) it will use an in-memory database |
 | allowMainThread | If you have legacy code that temporarily needs to make calls from the main thread, this can be your friend |
 | callback | A callback for database state changes |
+| cache | When null (default), no caching is used. Otherwise, you can specify an implementation of `VesselCache` to enable caching: `DefaultCache` or `LruCache` |
 
 Let's look at the callback a little closer.
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ val vessel = VesselImpl(
 | inMemory | When false (default) it will use a SQL database.  When true (for example, in tests) it will use an in-memory database |
 | allowMainThread | If you have legacy code that temporarily needs to make calls from the main thread, this can be your friend |
 | callback | A callback for database state changes |
-| cache | When null (default), no caching is used. Otherwise, you can specify an implementation of `VesselCache` to enable caching: `DefaultCache` or `LruCache` |
+| cache | When null (default), no caching is used. Otherwise, you can specify an implementation of `VesselCache` to enable caching: `DefaultCache` and `LruCache` are included |
+
 
 Let's look at the callback a little closer.
 
@@ -142,6 +143,14 @@ Let's look at the callback a little closer.
 | onDestructiveMigration | Called when the database has been migrated destructively | 
 
 In the above example, we are simply calling `Log.d` from the callbacks. If you are calling it from Robolectric, you might consider using `println` instead.
+
+
+Vessel also comes with the ability to add an in-memory cache to speed up retrieval. You can provide your own implementation of `VesselCache`, or you can use the built-in caches included with Vessel.
+
+| Cache | Description |
+| :--- | :--- |
+| DefaultCache | There is no eviction policy and all objects are retained until the app process is killed |
+| LruCache | There is a maximum capacity (# of objects) and the Least Recently Used key is evicted when full |
 
 ### API
 

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCache.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCache.kt
@@ -7,22 +7,22 @@ interface VesselCache {
     val size: Int
 
     /**
-     * Get the value of [key], returning null if key is not present
+     * Get the value of [key], returning null if [key] is not present in the cache
      */
     fun <T : Any> get(key: String): T?
 
     /**
-     * Sets [key] to [value] in the cache
+     * Set [key] to [value] in the cache
      */
     fun <T : Any> set(key: String, value: T)
 
     /**
-     * Removes [key] from the cache
+     * Remove [key] from the cache
      */
     fun remove(key: String)
 
     /**
-     * Clears the cache
+     * Clear the cache of all data
      */
     fun clear()
 }

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCache.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCache.kt
@@ -1,9 +1,28 @@
 package com.textnow.android.vessel
 
 interface VesselCache {
+    /**
+     * Get the current size of the cache
+     */
     val size: Int
-    suspend fun <T : Any> get(key: String): T?
-    suspend fun <T : Any> set(key: String, value: T)
-    suspend fun remove(key: String)
-    suspend fun clear()
+
+    /**
+     * Get the value of [key], returning null if key is not present
+     */
+    fun <T : Any> get(key: String): T?
+
+    /**
+     * Sets [key] to [value] in the cache
+     */
+    fun <T : Any> set(key: String, value: T)
+
+    /**
+     * Removes [key] from the cache
+     */
+    fun remove(key: String)
+
+    /**
+     * Clears the cache
+     */
+    fun clear()
 }

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCache.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCache.kt
@@ -1,0 +1,9 @@
+package com.textnow.android.vessel
+
+interface VesselCache {
+    val size: Int
+    suspend fun <T : Any> get(key: String): T?
+    suspend fun <T : Any> set(key: String, value: T)
+    suspend fun remove(key: String)
+    suspend fun clear()
+}

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCache.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCache.kt
@@ -2,7 +2,7 @@ package com.textnow.android.vessel
 
 interface VesselCache {
     /**
-     * Get the current size of the cache
+     * The number of items currently in the cache
      */
     val size: Int
 

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCacheImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCacheImpl.kt
@@ -10,19 +10,19 @@ open class DefaultVesselCache : VesselCache {
         get() = hashMap.size
 
     @Suppress("UNCHECKED_CAST")
-    override suspend fun <T : Any> get(key: String): T? {
+    override fun <T : Any> get(key: String): T? {
         return hashMap[key] as? T?
     }
 
-    override suspend fun <T : Any> set(key: String, value: T) {
+    override fun <T : Any> set(key: String, value: T) {
         hashMap[key] = value
     }
 
-    override suspend fun remove(key: String) {
+    override fun remove(key: String) {
         hashMap.remove(key)
     }
 
-    override suspend fun clear() {
+    override fun clear() {
         hashMap.clear()
     }
 }
@@ -38,13 +38,13 @@ open class LRUVesselCache(
     override val size: Int
         get() = backingCache.size
 
-    override suspend fun <T : Any> get(key: String): T? {
+    override fun <T : Any> get(key: String): T? {
         return backingCache.get<T>(key)?.also {
             moveToEnd(key)
         }
     }
 
-    override suspend fun <T : Any> set(key: String, value: T) {
+    override fun <T : Any> set(key: String, value: T) {
         moveToEnd(key)
         backingCache.set(key, value)
 
@@ -54,12 +54,12 @@ open class LRUVesselCache(
         }
     }
 
-    override suspend fun remove(key: String) {
+    override fun remove(key: String) {
         evictionOrder.remove(key)
         backingCache.remove(key)
     }
 
-    override suspend fun clear() {
+    override fun clear() {
         backingCache.clear()
         evictionOrder.clear()
     }

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCacheImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCacheImpl.kt
@@ -40,12 +40,12 @@ open class LRUVesselCache(
 
     override fun <T : Any> get(key: String): T? {
         return backingCache.get<T>(key)?.also {
-            moveToEnd(key)
+            updateRecentlyUsed(key)
         }
     }
 
     override fun <T : Any> set(key: String, value: T) {
-        moveToEnd(key)
+        updateRecentlyUsed(key)
         backingCache.set(key, value)
 
         if (capacity > 0 && backingCache.size > capacity) {
@@ -64,7 +64,10 @@ open class LRUVesselCache(
         evictionOrder.clear()
     }
 
-    private fun moveToEnd(key: String) {
+    /**
+     * Moves [key] to the end of [evictionOrder]
+     */
+    private fun updateRecentlyUsed(key: String) {
         evictionOrder.remove(key)
         evictionOrder.addLast(key)
     }

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCacheImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCacheImpl.kt
@@ -3,6 +3,10 @@ package com.textnow.android.vessel
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedDeque
 
+/**
+ * [DefaultVesselCache] has no max size and no eviction policy. Data is stored
+ * in memory until the process is killed, or [clear] is called.
+ */
 open class DefaultVesselCache : VesselCache {
     private val hashMap = ConcurrentHashMap<String, Any>()
 
@@ -27,6 +31,11 @@ open class DefaultVesselCache : VesselCache {
     }
 }
 
+/**
+ * [LRUVesselCache] has a max size of [capacity]. Adding a new key when the cache is full
+ * results in the least recently used key to be evicted. Data is stored
+ * in memory until the process is killed, or [clear] is called.
+ */
 open class LRUVesselCache(
     private val capacity: Int
 ) : VesselCache {

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCacheImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCacheImpl.kt
@@ -4,10 +4,10 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedDeque
 
 /**
- * [DefaultVesselCache] has no max size and no eviction policy. Data is stored
+ * [DefaultCache] has no max size and no eviction policy. Data is stored
  * in memory until the process is killed, or [clear] is called.
  */
-open class DefaultVesselCache : VesselCache {
+open class DefaultCache : VesselCache {
     private val hashMap = ConcurrentHashMap<String, Any>()
 
     override val size: Int
@@ -32,14 +32,14 @@ open class DefaultVesselCache : VesselCache {
 }
 
 /**
- * [LRUVesselCache] has a max size of [capacity]. Adding a new key when the cache is full
+ * [LruCache] has a max size of [capacity]. Adding a new key when the cache is full
  * results in the least recently used key to be evicted. Data is stored
  * in memory until the process is killed, or [clear] is called.
  */
-open class LRUVesselCache(
+open class LruCache(
     private val capacity: Int
 ) : VesselCache {
-    private val backingCache: VesselCache = DefaultVesselCache()
+    private val backingCache: VesselCache = DefaultCache()
 
     // front is the LRU key; end is the most recent used key
     private val evictionOrder = ConcurrentLinkedDeque<String>()

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCacheImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselCacheImpl.kt
@@ -1,0 +1,72 @@
+package com.textnow.android.vessel
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedDeque
+
+open class DefaultVesselCache : VesselCache {
+    private val hashMap = ConcurrentHashMap<String, Any>()
+
+    override val size: Int
+        get() = hashMap.size
+
+    @Suppress("UNCHECKED_CAST")
+    override suspend fun <T : Any> get(key: String): T? {
+        return hashMap[key] as? T?
+    }
+
+    override suspend fun <T : Any> set(key: String, value: T) {
+        hashMap[key] = value
+    }
+
+    override suspend fun remove(key: String) {
+        hashMap.remove(key)
+    }
+
+    override suspend fun clear() {
+        hashMap.clear()
+    }
+}
+
+open class LRUVesselCache(
+    private val capacity: Int
+) : VesselCache {
+    private val backingCache: VesselCache = DefaultVesselCache()
+
+    // front is the LRU key; end is the most recent used key
+    private val evictionOrder = ConcurrentLinkedDeque<String>()
+
+    override val size: Int
+        get() = backingCache.size
+
+    override suspend fun <T : Any> get(key: String): T? {
+        return backingCache.get<T>(key)?.also {
+            moveToEnd(key)
+        }
+    }
+
+    override suspend fun <T : Any> set(key: String, value: T) {
+        moveToEnd(key)
+        backingCache.set(key, value)
+
+        if (capacity > 0 && backingCache.size > capacity) {
+            val toRemove = evictionOrder.removeFirst()
+            backingCache.remove(toRemove)
+        }
+    }
+
+    override suspend fun remove(key: String) {
+        evictionOrder.remove(key)
+        backingCache.remove(key)
+    }
+
+    override suspend fun clear() {
+        backingCache.clear()
+        evictionOrder.clear()
+    }
+
+    private fun moveToEnd(key: String) {
+        evictionOrder.remove(key)
+        evictionOrder.addLast(key)
+    }
+
+}

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
@@ -48,6 +48,7 @@ import kotlin.reflect.KClass
  * @param inMemory true if the database should be in-memory only [Default: false]
  * @param allowMainThread to allow calls to be made on the main thread. [Default: false]
  * @param callback for notifications of database state changes
+ * @param cache Optional [VesselCache]. Built-ins: [DefaultVesselCache] and [LRUVesselCache] [Default: null]
  */
 class VesselImpl(
         private val appContext: Context,

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
@@ -48,7 +48,7 @@ import kotlin.reflect.KClass
  * @param inMemory true if the database should be in-memory only [Default: false]
  * @param allowMainThread to allow calls to be made on the main thread. [Default: false]
  * @param callback for notifications of database state changes
- * @param cache Optional [VesselCache]. Built-ins: [DefaultVesselCache] and [LRUVesselCache] [Default: null]
+ * @param cache Optional [VesselCache]. Built-ins: [DefaultCache] and [LruCache] [Default: null]
  */
 class VesselImpl(
         private val appContext: Context,

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/BaseVesselTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/BaseVesselTest.kt
@@ -27,9 +27,13 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.textnow.android.vessel.di.testModule
 import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.Koin
+import org.koin.core.context.stopKoin
+import org.koin.core.parameter.parametersOf
+import org.koin.test.AutoCloseKoinTest
 import org.koin.test.KoinTest
 import org.koin.test.KoinTestRule
 import org.koin.test.inject
@@ -38,8 +42,8 @@ import org.koin.test.inject
  * Base test class to handle starting and stopping Koin,
  * setting up the test module dependency and closing the db.
  */
-abstract class BaseVesselTest : KoinTest {
-    val vessel: Vessel by inject()
+abstract class BaseVesselTest(cache: VesselCache? = null) : KoinTest {
+    val vessel: Vessel by inject { parametersOf(cache) }
 
     @get:Rule
     val koinTestRule = KoinTestRule.create {

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselCacheTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselCacheTest.kt
@@ -1,0 +1,122 @@
+package com.textnow.android.vessel
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import assertk.assertions.isZero
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+abstract class BaseVesselCacheTest<T : VesselCache> {
+    private lateinit var cache : T
+
+    abstract fun getInstance() : T
+
+    @Before
+    fun setUp() {
+        cache = getInstance()
+    }
+
+    @After
+    fun teardown() {
+        cache.clear()
+    }
+
+    @Test
+    fun `set the correct data for cache key`() {
+        cache.set("key", 3)
+        assertThat(cache.get<Int>("key")).isEqualTo(3)
+    }
+
+    @Test
+    fun `set changes value for same cache key`() {
+        cache.set("key", 5)
+        cache.set("key", 7)
+        assertThat (cache.get<Int>("key")).isEqualTo(7)
+        assertThat(cache.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `remove removes the data from the cache`() {
+        cache.set("key", 3)
+        cache.set("key2", 5)
+
+        cache.remove("key2")
+        assertThat (cache.get<Int>("key2")).isNull()
+        assertThat(cache.size).isEqualTo(1)
+
+        cache.remove("key")
+        assertThat(cache.get<Int>("key")).isNull()
+        assertThat(cache.size).isZero()
+    }
+
+    @Test
+    fun `remove nonexistent produces no error`() {
+        // should not error
+        cache.remove("test")
+    }
+
+    @Test
+    fun `get produces correct values`() {
+        cache.set("key", 3)
+        cache.set("key", 4)
+        cache.set("other", 5)
+        assertThat(cache.get<Int>("key")).isEqualTo(4)
+        assertThat(cache.get<Int>("other")).isEqualTo(5)
+        assertThat(cache.size).isEqualTo(2)
+    }
+
+    @Test
+    fun `get non-existent key produces null`() {
+        assertThat(cache.get<Int>("key")).isNull()
+    }
+
+    @Test
+    fun `clear removes all data`() {
+        assertThat(cache.size).isZero()
+        cache.set("key", 5)
+        cache.set("key2", 6)
+        cache.set("key", 7)
+        assertThat(cache.size).isEqualTo(2)
+        cache.clear()
+        assertThat(cache.size).isEqualTo(0)
+        assertThat(cache.get<Int>("key")).isNull()
+    }
+
+}
+
+@RunWith(JUnit4::class)
+class DefaultVesselCacheTest : BaseVesselCacheTest<DefaultVesselCache>() {
+    override fun getInstance(): DefaultVesselCache {
+        return DefaultVesselCache()
+    }
+}
+
+@RunWith(JUnit4::class)
+class LRUVesselCacheTest : BaseVesselCacheTest<LRUVesselCache>() {
+    override fun getInstance(): LRUVesselCache {
+        return LRUVesselCache(100)
+    }
+
+    @Test
+    fun `evicts LRU key when cache reaches capacity`() {
+        val lruCache = LRUVesselCache(3)
+        lruCache.set("key", 1)
+        lruCache.set("key2", 2)
+        lruCache.set("key3", 3)
+        assertThat(lruCache.size).isEqualTo(3)
+        lruCache.set("key4", 4)
+        assertThat(lruCache.size).isEqualTo(3)
+        assertThat(lruCache.get<Int>("key")).isNull()
+
+        // move key3 as recently used key
+        lruCache.get<Int>("key3")
+        lruCache.set("key5", 5)
+        assertThat(lruCache.size).isEqualTo(3)
+        assertThat(lruCache.get<Int>("key2")).isNull()
+        assertThat(lruCache.get<Int>("key5")).isEqualTo(5)
+    }
+}

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselCacheTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselCacheTest.kt
@@ -89,21 +89,21 @@ abstract class BaseVesselCacheTest<T : VesselCache> {
 }
 
 @RunWith(JUnit4::class)
-class DefaultVesselCacheTest : BaseVesselCacheTest<DefaultVesselCache>() {
-    override fun getInstance(): DefaultVesselCache {
-        return DefaultVesselCache()
+class DefaultCacheTest : BaseVesselCacheTest<DefaultCache>() {
+    override fun getInstance(): DefaultCache {
+        return DefaultCache()
     }
 }
 
 @RunWith(JUnit4::class)
-class LRUVesselCacheTest : BaseVesselCacheTest<LRUVesselCache>() {
-    override fun getInstance(): LRUVesselCache {
-        return LRUVesselCache(100)
+class LruCacheTest : BaseVesselCacheTest<LruCache>() {
+    override fun getInstance(): LruCache {
+        return LruCache(100)
     }
 
     @Test
     fun `evicts LRU key when cache reaches capacity`() {
-        val lruCache = LRUVesselCache(3)
+        val lruCache = LruCache(3)
         lruCache.set("key", 1)
         lruCache.set("key2", 2)
         lruCache.set("key3", 3)

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselImplTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselImplTest.kt
@@ -33,19 +33,16 @@ import com.textnow.android.vessel.model.*
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.runners.Parameterized
 import org.robolectric.annotation.Config
 
 /**
  * Validate functionality of the Vessel implementation.
  * These tests will rely on the in-memory room database so we can verify proper serialization.
+ * Tests Vessel with caching and non-caching functionality
  */
-@RunWith(AndroidJUnit4::class)
-@Config(
-    sdk = [Build.VERSION_CODES.P],
-    manifest = Config.NONE
-)
-class VesselImplTest: BaseVesselTest() {
-
+abstract class VesselImplTest(cache: VesselCache?): BaseVesselTest(cache) {
     @Test
     fun `reasonable names are chosen for data`() {
         assertThat(vessel.typeNameOf(firstSimple)).isEqualTo("com.textnow.android.vessel.model.SimpleData")
@@ -146,6 +143,7 @@ class VesselImplTest: BaseVesselTest() {
         assertThat(vessel.get(SimpleDataV2::class)?.number).isEqualTo(replacement.number)
     }
 
+    @Test
     fun `writing the same data type replaces the value`() = runBlocking {
         vessel.set(firstSimple)
         vessel.set(secondSimple)
@@ -163,3 +161,19 @@ class VesselImplTest: BaseVesselTest() {
         assertThat(vessel.get(NestedData::class)).isNull()
     }
 }
+
+// Workaround for parameterized tests
+
+@Config(
+    sdk = [Build.VERSION_CODES.P],
+    manifest = Config.NONE
+)
+@RunWith(AndroidJUnit4::class)
+class VesselImplTestNoCache : VesselImplTest(null)
+
+@Config(
+    sdk = [Build.VERSION_CODES.P],
+    manifest = Config.NONE
+)
+@RunWith(AndroidJUnit4::class)
+class VesselImplTestCached : VesselImplTest(DefaultVesselCache())

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselImplTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselImplTest.kt
@@ -33,8 +33,6 @@ import com.textnow.android.vessel.model.*
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.runners.Parameterized
 import org.robolectric.annotation.Config
 
 /**
@@ -180,4 +178,4 @@ class VesselImplTestNoCache : VesselImplTest(null)
     manifest = Config.NONE
 )
 @RunWith(AndroidJUnit4::class)
-class VesselImplTestCached : VesselImplTest(DefaultVesselCache())
+class VesselImplTestCached : VesselImplTest(DefaultCache())

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/di/TestModule.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/di/TestModule.kt
@@ -23,6 +23,7 @@
  */
 package com.textnow.android.vessel.di
 
+import com.textnow.android.vessel.DefaultVesselCache
 import com.textnow.android.vessel.Vessel
 import com.textnow.android.vessel.VesselCallback
 import com.textnow.android.vessel.VesselImpl
@@ -42,7 +43,8 @@ val testModule = module {
                 onOpen = { println("Database opened") },
                 onClosed = { println("Database closed") },
                 onDestructiveMigration = { println("Destructive migration") }
-            )
+            ),
+            cache = DefaultVesselCache()
         )
     }
 }

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/di/TestModule.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/di/TestModule.kt
@@ -23,10 +23,7 @@
  */
 package com.textnow.android.vessel.di
 
-import com.textnow.android.vessel.DefaultVesselCache
-import com.textnow.android.vessel.Vessel
-import com.textnow.android.vessel.VesselCallback
-import com.textnow.android.vessel.VesselImpl
+import com.textnow.android.vessel.*
 import org.koin.dsl.module
 
 /**
@@ -34,7 +31,7 @@ import org.koin.dsl.module
  */
 val testModule = module {
     single<Vessel> {
-        VesselImpl(
+        (cache: VesselCache?) -> VesselImpl(
             appContext = get(),
             inMemory = true,
             allowMainThread = true,
@@ -44,7 +41,7 @@ val testModule = module {
                 onClosed = { println("Database closed") },
                 onDestructiveMigration = { println("Destructive migration") }
             ),
-            cache = DefaultVesselCache()
+            cache = cache
         )
     }
 }


### PR DESCRIPTION
Fixes [VSL-3](https://github.com/textnow/vessel/issues/3)

### Context
Currently, every request requires hitting the disk via Room. This can be expensive in situations where I/O is blocked, or there are not enough threads in the thread pool. By using a cache, retrieving data from vessel becomes much less costly on the average case.

### Considerations
- Wanted to avoid using another library in order to keep the library light
- Although a cache is not as important as DB in terms of data consistency, it's still ideal that it is thread-safe, and can handle concurrent accesses/writes.
- Wanted users to be able to define their own caching mechanism and supply the Vessel instance with it

### Changes

- Added support for vessel to have an optional [VesselCache] instance passed in. Currently, two caches are provided by default: [DefaultVesselCache] and [LRUVesselCache]. 
- Used [ConcurrentHashMap] and [ConcurrentLinkedDeque] for thread-safe implementation. I chose this over using mutex and locks because the library implementations optimize to allow multiple threads access and write the data, whereas a mutex allows at most one. This is the most performant approach, but may result in data inconsistency (see this [SO Post](https://stackoverflow.com/questions/510632/whats-the-difference-between-concurrenthashmap-and-collections-synchronizedmap))

### Possible Improvements
- For an unlimited cache (DefaultVesselCache), we could work with the vessel data completely in memory, and can update the disk in a background thread. This makes writes just as fast as cache hits, and sees the most performance improvements in setBlocking calls
- Could substitute the concurrent structures in favour of synchronized or using mutex. This ensures only one thread can access the cache at a time and thus data consistency, but may not be as performant
- For smaller databases, it would be beneficial to pre-load the entire database in memory once and operate in memory, and simply persist the change to disk in a background thread

### Concerns/Questions
- Instead of serializing the data objects, I decided to go with casting types. This is more performant since it avoids the overhead of reflection/ gson serialization. Since vessel always uses the type of the class as a parameter, the cast should always succeed
- LRUCache uses two separate concurrent structures to perform the LRU cache. Although each structure is thread-safe by itself,  the object as a whole may not be thread-safe. I wanted to keep the structures for performance reasons, but I want to ask whether the cache integrity would be compromised by parallel updates/gets to the cache (specifically, in the set)

https://github.com/textnow/vessel/compare/master...sriharivishnu:add-optional-cache?expand=1#diff-1729c510c0fb0197ab8bc25a47900f21def98d9d873cff0ec88d781edae442b4R47-R55
```
    override fun <T : Any> set(key: String, value: T) {
        updateRecentlyUsed(key)
        backingCache.set(key, value)

        if (capacity > 0 && backingCache.size > capacity) {
            val toRemove = evictionOrder.removeFirst()
            backingCache.remove(toRemove)
        }
    }
```
