### PR TITLE
[VSL-24] Fix code coverage

### DIFF
--- a/.github/scripts/generateCoverageBadge.sh
+++ b/.github/scripts/generateCoverageBadge.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-REPORT=vessel-runtime/build/reports/jacoco/debug/jacoco.xml
+REPORT=build/reports/kover/report.xml
 if [ ! -f $REPORT ]; then
-  echo "$REPORT not found. Did you run 'jacocoTestReportDebug' first?"
+  echo "$REPORT not found. Did you run 'koverMergedReport' first?"
   exit 2
 fi
 

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -12,14 +12,14 @@ jobs:
           java-version: 11
 
       - name: Run Tests
-        run: ./gradlew test jacocoTestReportDebug --stacktrace
+        run: ./gradlew koverMergedReport --stacktrace
 
       - name: Archive Reports
         if: always()
         uses: actions/upload-artifact@v2
         with:
           name: 'reports'
-          path: vessel-runtime/build/reports/
+          path: build/reports/
 
       - name: Assemble
         run: ./gradlew assemble

--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -67,7 +67,7 @@ jobs:
           java-version: 11
 
       - name: Run Tests
-        run: ./gradlew test jacocoTestReportDebug
+        run: ./gradlew koverMergedReport
 
       - name: Update Coverage Badge
         run: .github/scripts/generateCoverageBadge.sh
@@ -83,7 +83,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: 'reports'
-          path: vessel-runtime/build/reports/
+          path: build/reports/
 
   # Assemble debug and release, just as an extra validation step
   assemble:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [VSL-24](https://github.com/textnow/vessel/issues/24) Change code coverage engine to Kover + IntelliJ
+
+### Removed
+
+- Remove `manifest =` lines from Robolectric `@Config` as per http://robolectric.org/migrating/#migrating-to-40
+- Remove `@ExperimentalCoroutinesApi` from `flow` accessor due to IDE recommendation
+
 ## [0.1.2] - 2022-03-23
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@ buildscript {
 }
 
 plugins {
-    id("com.vanniktech.android.junit.jacoco") version Versions.vannikJacoco
     id("org.jetbrains.dokka") version Versions.dokka
     id("org.jetbrains.kotlinx.kover") version Versions.kover
 }
@@ -30,7 +29,6 @@ kover {
     isDisabled = false                                   // true to disable instrumentation of all test tasks in all projects
     coverageEngine.set(kotlinx.kover.api.CoverageEngine.INTELLIJ) // change instrumentation agent and reporter
     intellijEngineVersion.set(Versions.intellijCover)    // change version of IntelliJ agent and reporter
-    jacocoEngineVersion.set(Versions.jacoco)             // change version of JaCoCo agent and reporter
     generateReportOnCheck = true                         // false to do not execute `koverMergedReport` task before `check` task
     disabledProjects = setOf()                           // setOf("project-name") or setOf(":project-name") to disable coverage for project with path `:project-name` (`:` for the root project)
     instrumentAndroidPackage = false                     // true to instrument packages `android.*` and `com.android.*`
@@ -48,21 +46,3 @@ tasks {
     }
 }
 
-junitJacoco {
-    jacocoVersion = Versions.jacoco
-    excludes = listOf(
-        // Auto-generated code
-        "**/BuildConfig.*",
-        "**/*_Impl.*",
-        "**/*_Impl\$*.*",
-        // Jacoco can't handle these
-        "**/*\$Lambda\$*.*",
-        "**/*\$inlined\$*.*",
-        // Doesn't make sense to test these
-        "**/NoOp*.*",
-        "**/LoggingKt.*",
-        "jdk.internal.*"
-    )
-    includeNoLocationClasses = false
-    includeInstrumentationCoverageInMergedReport = true
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ buildscript {
 plugins {
     id("com.vanniktech.android.junit.jacoco") version Versions.vannikJacoco
     id("org.jetbrains.dokka") version Versions.dokka
+    id("org.jetbrains.kotlinx.kover") version Versions.kover
 }
 
 allprojects {
@@ -23,6 +24,17 @@ allprojects {
         google()
         jcenter()
     }
+}
+
+kover {
+    isDisabled = false                                   // true to disable instrumentation of all test tasks in all projects
+    coverageEngine.set(kotlinx.kover.api.CoverageEngine.INTELLIJ) // change instrumentation agent and reporter
+    intellijEngineVersion.set(Versions.intellijCover)    // change version of IntelliJ agent and reporter
+    jacocoEngineVersion.set(Versions.jacoco)             // change version of JaCoCo agent and reporter
+    generateReportOnCheck = true                         // false to do not execute `koverMergedReport` task before `check` task
+    disabledProjects = setOf()                           // setOf("project-name") or setOf(":project-name") to disable coverage for project with path `:project-name` (`:` for the root project)
+    instrumentAndroidPackage = false                     // true to instrument packages `android.*` and `com.android.*`
+    runAllTestsForProjectTask = false                    // true to run all tests in all projects if `koverHtmlReport`, `koverXmlReport`, `koverReport`, `koverVerify` or `check` tasks executed on some project
 }
 
 tasks {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -24,8 +24,6 @@
 object Versions {
     const val kotlin = "1.5.21"
     const val androidGradle = "7.0.2"
-    const val vannikJacoco = "0.16.0"
-    const val jacoco = "0.8.7"
     const val dokka = "1.4.10"
     const val kover = "0.5.0"
     const val intellijCover = "1.0.656"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -27,6 +27,8 @@ object Versions {
     const val vannikJacoco = "0.16.0"
     const val jacoco = "0.8.7"
     const val dokka = "1.4.10"
+    const val kover = "0.5.0"
+    const val intellijCover = "1.0.656"
 
     const val coroutine = "1.5.1"
     const val room = "2.4.0-alpha04"

--- a/vessel-runtime/build.gradle.kts
+++ b/vessel-runtime/build.gradle.kts
@@ -58,9 +58,12 @@ android {
 
     testOptions {
         unitTests.apply {
-            // https://github.com/robolectric/robolectric/issues/5456
-            isIncludeAndroidResources = false
+            isIncludeAndroidResources = true
             isReturnDefaultValues = true
+            all {
+                it.systemProperty("robolectric.logging.enabled", "true")
+                it.jvmArgs("-noverify")
+            }
         }
     }
 }

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
@@ -324,7 +324,6 @@ class VesselImpl(
      * @param type of data class to lookup
      * @return flow of the values associated with that type
      */
-    @ExperimentalCoroutinesApi
     override fun <T : Any> flow(type: KClass<T>): Flow<T?> {
         check(!closeWasCalled) { "Vessel($name:${hashCode()}) was already closed." }
         type.qualifiedName?.let { typeName ->

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/FlowTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/FlowTest.kt
@@ -52,10 +52,7 @@ import org.robolectric.annotation.Config
  */
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
-@Config(
-    sdk = [Build.VERSION_CODES.P],
-    manifest = Config.NONE
-)
+@Config(sdk = [Build.VERSION_CODES.P])
 class FlowTest : BaseVesselTest() {
     private val dispatcher = TestCoroutineDispatcher()
     private val scope = TestCoroutineScope(dispatcher)

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/JavaAccessTest.java
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/JavaAccessTest.java
@@ -45,10 +45,7 @@ import static org.junit.Assert.assertNull;
  * This subset of tests only validates the Java-specific accessors.
  */
 @RunWith(AndroidJUnit4.class)
-@Config(
-        sdk = Build.VERSION_CODES.P,
-        manifest = Config.NONE
-)
+@Config(sdk = Build.VERSION_CODES.P)
 public class JavaAccessTest extends BaseVesselTest {
 
     public JavaAccessTest() {

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/LiveDataTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/LiveDataTest.kt
@@ -49,10 +49,7 @@ import org.robolectric.annotation.Config
  * tested separately.
  */
 @RunWith(AndroidJUnit4::class)
-@Config(
-    sdk = [Build.VERSION_CODES.P],
-    manifest = Config.NONE
-)
+@Config(sdk = [Build.VERSION_CODES.P])
 class LiveDataTest : BaseVesselTest() {
     @get:Rule
     val instantExecutorRule = InstantTaskExecutorRule()

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselImplTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselImplTest.kt
@@ -166,16 +166,10 @@ abstract class VesselImplTest(cache: VesselCache?): BaseVesselTest(cache) {
 
 // Workaround for parameterized tests
 
-@Config(
-    sdk = [Build.VERSION_CODES.P],
-    manifest = Config.NONE
-)
+@Config(sdk = [Build.VERSION_CODES.P])
 @RunWith(AndroidJUnit4::class)
 class VesselImplTestNoCache : VesselImplTest(null)
 
-@Config(
-    sdk = [Build.VERSION_CODES.P],
-    manifest = Config.NONE
-)
+@Config(sdk = [Build.VERSION_CODES.P])
 @RunWith(AndroidJUnit4::class)
 class VesselImplTestCached : VesselImplTest(DefaultCache())


### PR DESCRIPTION
JaCoCo has been broken since upgrading to JDK11.
For now, at least, changing over to Kover + IntelliJ to get coverage reporting working.

Resolves #24