### PR TITLE
 Add more error handling and recovery to preload()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   `preload`/`preloadBlocking` now return a status object `PreloadReport` which contains info about any errors encountered while preloading
+-   `preload`/`preloadBlocking` now catch errors during deserialization of individual values - any errors here are reported in the `PreloadReport` (as above)
+-   For completeness similar info has been added to the profiling data (see `Vessel.snapshot`)
+-   Fixed issue #36
+
 ## [1.0.0] - 2023-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ changed or no longer exists, it will fail to deserialize.  This can happen if yo
 remove types/values that fall out of use, or if your application does not migrate one type to another 
 (see `replaceBlocking` below, which can be used to migrate values).
 
-To help with this, `preload` returns a status object `PreloadBlocking` that will indicate if any such 
+To help with this, `preload` returns a status object `PreloadReport` that will indicate if any such 
 errors occur - which types failed to deserialize and why.  The profiling data also includes a subset
 of this report.
 

--- a/README.md
+++ b/README.md
@@ -205,9 +205,22 @@ Kotlin:
 vessel.deleteBlocking(SimpleData::class)
 ```
 
-All values can be read into the cache using `preload`.
+All values can be read into the cache using `preloadBlocking`.
 
-This can increase performance depending on your data access patterns (see [profiling](#profiling) below)
+This can increase performance depending on your data access patterns (see [profiling](#profiling) below).
+
+Since preloading reads all values from the database, this may end up reading old types/values your 
+application is no longer using.  
+
+If your application's code has changed such that the type definition for such a value has 
+changed or no longer exists, it will fail to deserialize.  This can happen if your application does not 
+remove types/values that fall out of use, or if your application does not migrate one type to another 
+(see `replaceBlocking` below, which can be used to migrate values).
+
+To help with this, `preload` returns a status object `PreloadBlocking` that will indicate if any such 
+errors occur - which types failed to deserialize and why.  The profiling data also includes a subset
+of this report.
+
 
 ```
 vessel.preloadBlocking()

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/NoOpVessel.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/NoOpVessel.kt
@@ -37,8 +37,8 @@ import kotlin.reflect.KClass
 class NoOpVessel : Vessel {
     override fun <T : Any> typeNameOf(value: T): String = "no-op"
     override fun close() { /* no-op */ }
-    override suspend fun preload(timeoutMS: Int?) { /* no-op */ }
-    override fun preloadBlocking(timeoutMS: Int?) { /* no-op */ }
+    override suspend fun preload(timeoutMS: Int?) = PreloadReport()
+    override fun preloadBlocking(timeoutMS: Int?) = PreloadReport()
 
     override val profileData: ProfileData? = null
     override fun <T : Any> getBlocking(type: KClass<T>): T? = null

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/PreloadReport.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/PreloadReport.kt
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2020 TextNow, Inc.
+ * Copyright (c) 2023 TextNow, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/PreloadReport.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/PreloadReport.kt
@@ -1,3 +1,27 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020 TextNow, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.textnow.android.vessel
 
 /**

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/PreloadReport.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/PreloadReport.kt
@@ -1,0 +1,47 @@
+package com.textnow.android.vessel
+
+/**
+ * The result of calling [Vessel.preload]/[Vessel.preloadBlocking].
+ *
+ * This indicates which errors occurred during preloading and whether the
+ * preload timeout was hit (if specified)
+ *
+ * This does not mean preloading failed entirely - any valid data will still be preloaded.
+ */
+data class PreloadReport(
+    /**
+     * List of types for which there was no type definition found at runtime.
+     *
+     * This can occur when a type is removed from code that uses Vessel, but an instance
+     * of that type remains stored in Vessel.
+     */
+    var missingTypes: MutableList<String> = mutableListOf(),
+
+    /**
+     * List of types where de-serialization failed.
+     *
+     * That is, an instance of a type stored in Vessel could not be converted into the current
+     * representation of that type.
+     *
+     * This can occur when the definition of a type is changed, but an instance of the old version of
+     * that type remains stored in Vessel.
+     *
+     * See [Vessel.replace], which can be used to instead swap one type for another, which
+     * is a technique that avoids this problem.  For example - rather than changing "MyData",
+     * define a new type "MyDataV2" and replace any instance of "MyData" in Vessel with "MyData2"
+     */
+    var deserializationErrors: MutableList<String> = mutableListOf(),
+
+    /**
+     * True if the preload timeout was exceeded (see timeoueMS in [Vessel.preload])
+     */
+    var timedOut: Boolean = false,
+
+    /**
+     * Indicates if one or more errors occurred during preloading:
+     * - missing types
+     * - deserializaiton errors
+     * - preload timeout exceeded
+     */
+    var errorsOcurred: Boolean = false,
+)

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/Profiler.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/Profiler.kt
@@ -55,7 +55,7 @@ enum class Span {
  */
 enum class Event {
     /**
-     * Cache hit events - shows effectiveness of caching
+     * Cache hit events - shows effectiveness of caching.
      */
 
     CACHE_HIT_READ,
@@ -64,10 +64,28 @@ enum class Event {
     CACHE_HIT_REPLACE,
 
     /**
-     * A timeout occurred during a call to [Vessel.preload], resulting in the preload being
-     * stopped.  Some data will likely still be preloaded, but not all
+     * Indicates the [Vessel.preload] timeout was exceeded (if specified).
+     * Analogous to [PreloadReport.timedOut], included here for completeness.
      */
-    PRELOAD_TIMEOUT;
+    PRELOAD_TIMEOUT,
+
+    /**
+     * Indicates the definitionof a type could not be found, either during [Vessel.preload] or as part of any
+     * [Vessel.get] or [Vessel.set] call.
+     *
+     * See [PreloadReport.missingTypes] for more information.
+     */
+    TYPE_NOT_FOUND,
+
+    /**
+     * Indicates the persisted data for a type could not be deserialized into its current
+     * representation.
+     *
+     * This may occur as part of a call to [Vessel.preload] or [Vessel.get].
+     *
+     * See [PreloadReport.deserializationErrors] for more information.
+     */
+    DESERIALIZATION_ERROR;
 
     /**
      * Friendly name for each enum - ex, "read", "delete", etc.

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/Vessel.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/Vessel.kt
@@ -63,12 +63,12 @@ interface Vessel {
      *
      * @param timeoutMS Optional timeout - stop the preload operation once execution time exceeds [timeoutMS]
      */
-    suspend fun preload(timeoutMS: Int? = null)
+    suspend fun preload(timeoutMS: Int? = null): PreloadReport
 
     /**
      * Blocking version of [preload].
      */
-    fun preloadBlocking(timeoutMS: Int? = null)
+    fun preloadBlocking(timeoutMS: Int? = null): PreloadReport
 
     // endregion
 

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
@@ -214,7 +214,11 @@ class VesselImpl(
     // region profiling
 
     override val profileData
-        get() = profiler.snapshot
+        get() = if (DummyProfiler::class.isInstance(profiler)) {
+            null
+        } else {
+            profiler.snapshot
+        }
 
     // endregion
 

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
@@ -184,7 +184,7 @@ class VesselImpl(
             return PreloadReport(errorsOcurred = true)
         }
 
-        val report = profiler.time(Span.PRELOAD_FROM_DB) {
+        return profiler.time(Span.PRELOAD_FROM_DB) {
             /**
              * This is exactly the same pattern that the Room code generator emits/
              * Implementing this way so preloading can bail out if a time limit is hit
@@ -197,8 +197,6 @@ class VesselImpl(
                 preloadImpl(timeoutMS)
             }
         }
-
-        return report
     }
 
     override fun preloadBlocking(timeoutMS: Int?): PreloadReport {
@@ -206,11 +204,9 @@ class VesselImpl(
             return PreloadReport(errorsOcurred = true)
         }
 
-        val report = profiler.timeBlocking(Span.PRELOAD_FROM_DB) {
+        return profiler.timeBlocking(Span.PRELOAD_FROM_DB) {
             preloadImpl(timeoutMS)
         }
-
-        return report
     }
 
     // endregion

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
@@ -155,7 +155,7 @@ class VesselImpl(
                 }
 
                 val obj = try {
-                        if (data != null) fromJson(data, kclass) else nullValue
+                    if (data != null) fromJson(data, kclass) else nullValue
                 } catch (error: Exception) {
                     report.deserializationErrors.add(type)
                     report.errorsOcurred = true
@@ -290,7 +290,7 @@ class VesselImpl(
      * in the database.  This can be used to avoid going to the database to determine if the value exists
      */
     private fun <T : Any> findCached(type: KClass<T>): Pair<Boolean, T?> {
-        // omitting use of qualifiedNameOf to avoid double-counting the CLASS_NOT_FOUND event
+        // omitting use of qualifiedNameOf to avoid double-counting the TYPE_NOT_FOUND event
         val typeName = type.qualifiedName ?: return Pair(false, null)
 
         return when (val lookup = cache?.get<T>(typeName)) {

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
@@ -59,6 +59,7 @@ class VesselImpl(
     private val callback: VesselCallback? = null,
     private val cache: VesselCache? = null,
     private val profile: Boolean = false,
+    externalDb: VesselDb? = null,
 ) : Vessel {
 
     /**
@@ -89,10 +90,7 @@ class VesselImpl(
         // other configuration
         .create()
 
-    /**
-     * Underlying Room instance.
-     */
-    private val db: VesselDb = when (inMemory) {
+    private val db: VesselDb = externalDb ?: when (inMemory) {
         true -> Room.inMemoryDatabaseBuilder(appContext, VesselDb::class.java)
         false -> Room.databaseBuilder(appContext, VesselDb::class.java, name)
     }
@@ -133,7 +131,7 @@ class VesselImpl(
      *
      * @return true only if the entire database could be loaded into cache in the allotted timeout
      */
-    private fun preloadImpl(timeoutMS: Int?): Boolean {
+    private fun preloadImpl(timeoutMS: Int?): PreloadReport {
         val cursor = db.query("SELECT * FROM vessel", emptyArray())
 
         cursor.use {
@@ -141,6 +139,8 @@ class VesselImpl(
             val dataCol = cursor.getColumnIndex("data")
 
             val startTimeMS = System.currentTimeMillis()
+            val report = PreloadReport()
+
             while (cursor.moveToNext()) {
                 val type = cursor.getString(typeCol)
                 val data = cursor.getString(dataCol)
@@ -148,31 +148,43 @@ class VesselImpl(
                 val kclass = try {
                     Class.forName(type).kotlin
                 } catch (error: Exception) {
+                    report.missingTypes.add(type)
+                    report.errorsOcurred = true
+                    profiler.countBlocking(Event.TYPE_NOT_FOUND)
                     continue
                 }
 
-                val obj = if (data != null) fromJson(data, kclass) else nullValue
+                val obj = try {
+                        if (data != null) fromJson(data, kclass) else nullValue
+                } catch (error: Exception) {
+                    report.deserializationErrors.add(type)
+                    report.errorsOcurred = true
+                    continue
+                }
+
                 cache?.set(type, obj as Any)
 
                 timeoutMS?.let {
                     val duration = System.currentTimeMillis() - startTimeMS
                     if (duration > it) {
+                        report.timedOut = true
+                        profiler.countBlocking(Event.PRELOAD_TIMEOUT)
                         cursor.close()
-                        return false
+                        return report
                     }
                 }
             }
 
-            return true
+            return report
         }
     }
 
-    override suspend fun preload(timeoutMS: Int?) {
+    override suspend fun preload(timeoutMS: Int?): PreloadReport {
         if (cache == null) {
-            return
+            return PreloadReport(errorsOcurred = true)
         }
 
-        val loadCompleted = profiler.time(Span.PRELOAD_FROM_DB) {
+        val report = profiler.time(Span.PRELOAD_FROM_DB) {
             /**
              * This is exactly the same pattern that the Room code generator emits/
              * Implementing this way so preloading can bail out if a time limit is hit
@@ -186,23 +198,19 @@ class VesselImpl(
             }
         }
 
-        if (!loadCompleted) {
-            profiler.count(Event.PRELOAD_TIMEOUT)
-        }
+        return report
     }
 
-    override fun preloadBlocking(timeoutMS: Int?) {
+    override fun preloadBlocking(timeoutMS: Int?): PreloadReport {
         if (cache == null) {
-            return
+            return PreloadReport(errorsOcurred = true)
         }
 
-        val loadCompleted = profiler.timeBlocking(Span.PRELOAD_FROM_DB) {
+        val report = profiler.timeBlocking(Span.PRELOAD_FROM_DB) {
             preloadImpl(timeoutMS)
         }
 
-        if (!loadCompleted) {
-            profiler.countBlocking(Event.PRELOAD_TIMEOUT)
-        }
+        return report
     }
 
     // endregion
@@ -219,7 +227,14 @@ class VesselImpl(
     /**
      * Convert a stored json string into the specified data type.
      */
-    private fun <T : Any> fromJson(value: String, type: KClass<T>): T? = gson.fromJson<T>(value, type.java)
+    private fun <T : Any> fromJson(value: String, type: KClass<T>): T? {
+        try {
+            return gson.fromJson(value, type.java)
+        } catch (error: Exception) {
+            profiler.countBlocking(Event.DESERIALIZATION_ERROR)
+            throw error
+        }
+    }
 
     /**
      * Convert a specified data type into a json string for storage.
@@ -230,8 +245,26 @@ class VesselImpl(
      * Get the type of the specified data.
      */
     @VisibleForTesting
-    override fun <T : Any> typeNameOf(value: T) = value.javaClass.kotlin.qualifiedName
-        ?: throw AssertionError("anonymous classes not allowed. their names will change if the parent code is changed.")
+    override fun <T : Any> typeNameOf(value: T): String {
+        val name = value.javaClass.kotlin.qualifiedName
+
+        if (name == null) {
+            profiler.countBlocking(Event.TYPE_NOT_FOUND)
+            throw AssertionError("anonymous classes not allowed. their names will change if the parent code is changed.")
+        }
+
+        return name
+    }
+
+    fun<T:Any> qualifiedNameOf(type: KClass<T>): String? {
+        val name = type.qualifiedName
+
+        if (name == null) {
+            profiler.countBlocking(Event.TYPE_NOT_FOUND)
+        }
+
+        return name
+    }
 
     /**
      * Close the database instance.
@@ -257,6 +290,7 @@ class VesselImpl(
      * in the database.  This can be used to avoid going to the database to determine if the value exists
      */
     private fun <T : Any> findCached(type: KClass<T>): Pair<Boolean, T?> {
+        // omitting use of qualifiedNameOf to avoid double-counting the CLASS_NOT_FOUND event
         val typeName = type.qualifiedName ?: return Pair(false, null)
 
         return when (val lookup = cache?.get<T>(typeName)) {
@@ -303,7 +337,7 @@ class VesselImpl(
             return value
         }
 
-        val typeName = type.qualifiedName ?: return null
+        val typeName = qualifiedNameOf(type) ?: return null
 
         return profiler.timeBlocking(Span.READ_FROM_DB) {
             dao.getBlocking(typeName)
@@ -367,7 +401,7 @@ class VesselImpl(
             return
         }
 
-        type.qualifiedName?.let { typeName ->
+        qualifiedNameOf(type)?.let { typeName ->
             profiler.timeBlocking(Span.DELETE_FROM_DB) {
                 dao.deleteBlocking(typeName)
             }
@@ -402,7 +436,7 @@ class VesselImpl(
             return value
         }
 
-        val typeName = type.qualifiedName ?: return null
+        val typeName = qualifiedNameOf(type) ?: return null
 
         return profiler.time(Span.READ_FROM_DB) {
             dao.get(typeName)
@@ -458,7 +492,7 @@ class VesselImpl(
             return
         }
 
-        type.qualifiedName?.let { typeName ->
+        qualifiedNameOf(type)?.let { typeName ->
             profiler.time(Span.DELETE_FROM_DB) {
                 dao.delete(typeName)
             }
@@ -498,7 +532,7 @@ class VesselImpl(
 
         val newName = typeNameOf(new)
 
-        oldType.qualifiedName?.let { oldName ->
+        qualifiedNameOf(oldType)?.let { oldName ->
             if (oldName == newName) {
                 set(new)
             } else {
@@ -555,7 +589,7 @@ class VesselImpl(
      */
     override fun <T : Any> flow(type: KClass<T>): Flow<T?> {
         check(!closeWasCalled) { "Vessel($name:${hashCode()}) was already closed." }
-        type.qualifiedName?.let { typeName ->
+        qualifiedNameOf(type)?.let { typeName ->
             return dao.getFlow(typeName)
                 .distinctUntilChanged()
                 .map {
@@ -577,7 +611,7 @@ class VesselImpl(
      */
     override fun <T : Any> livedata(type: KClass<T>): LiveData<T?> {
         check(!closeWasCalled) { "Vessel($name:${hashCode()}) was already closed." }
-        type.qualifiedName?.let { typeName ->
+        qualifiedNameOf(type)?.let { typeName ->
             return dao.getLiveData(typeName)
                 .distinctUntilChanged()
                 .map {

--- a/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
+++ b/vessel-runtime/src/main/java/com/textnow/android/vessel/VesselImpl.kt
@@ -169,7 +169,6 @@ class VesselImpl(
                     if (duration > it) {
                         report.timedOut = true
                         profiler.countBlocking(Event.PRELOAD_TIMEOUT)
-                        cursor.close()
                         return report
                     }
                 }

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/BaseVesselTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/BaseVesselTest.kt
@@ -27,13 +27,10 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.textnow.android.vessel.di.testModule
 import org.junit.After
-import org.junit.Before
 import org.junit.Rule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.Koin
-import org.koin.core.context.stopKoin
 import org.koin.core.parameter.parametersOf
-import org.koin.test.AutoCloseKoinTest
 import org.koin.test.KoinTest
 import org.koin.test.KoinTestRule
 import org.koin.test.inject
@@ -45,9 +42,10 @@ import org.koin.test.inject
 abstract class BaseVesselTest<T : VesselCache>(
     protected val cache: T? = null,
     protected val profile: Boolean = false,
-    protected val inMemory: Boolean = true
+    protected val inMemory: Boolean = true,
+    protected val db: VesselDb? = null,
 ) : KoinTest {
-    val vessel: Vessel by inject { parametersOf(cache, profile, inMemory) }
+    val vessel: Vessel by inject { parametersOf(cache, profile, inMemory, db) }
 
     @get:Rule
     val koinTestRule = KoinTestRule.create {

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/PreloadErrorHandlingTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/PreloadErrorHandlingTest.kt
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2020 TextNow, Inc.
+ * Copyright (c) 2023 TextNow, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/PreloadErrorHandlingTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/PreloadErrorHandlingTest.kt
@@ -1,5 +1,3 @@
-package com.textnow.android.vessel
-
 /**
  * MIT License
  *
@@ -23,6 +21,8 @@ package com.textnow.android.vessel
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+package com.textnow.android.vessel
 
 import android.os.Build
 import androidx.room.Room

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/PreloadErrorHandlingTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/PreloadErrorHandlingTest.kt
@@ -1,0 +1,132 @@
+package com.textnow.android.vessel
+
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020 TextNow, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import android.os.Build
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import com.textnow.android.vessel.model.*
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Ensure preload timeouts work as expected, and that the resulting data is still usable and correct
+ */
+abstract class ErrorHandlingTest(private val async: Boolean) :
+    BaseVesselTest<VesselCache>(
+        DefaultCache(),
+        true,
+        false,
+        Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            VesselDb::class.java
+        )
+            .allowMainThreadQueries()
+            .build()
+    ) {
+
+    private val vesselWrapper by lazy { VesselWrapper(vessel, async) }
+    private val dao = db!!.vesselDao()
+
+    @Test
+    fun `preload safely handles, and reports on, unknown types`(): Unit = runBlocking {
+        val badType = "com.some.type.DoesNotExist"
+        dao.set(VesselEntity(badType, "{}"))
+
+        vesselWrapper.set(firstSimple)
+
+        vesselWrapper.get(SimpleData::class)
+
+        val preloadReport = vesselWrapper.preload(1000)
+        val profileData = vesselWrapper.profileData!!
+
+        assertThat(preloadReport.errorsOcurred).isTrue()
+        assertThat(preloadReport.missingTypes).isEqualTo(listOf(badType))
+        assertThat(profileData.hitCountOf(Span.WRITE_TO_DB)).isEqualTo(1)
+        assertThat(profileData.hitCountOf(Event.CACHE_HIT_READ)).isEqualTo(1)
+        assertThat(profileData.hitCountOf(Event.TYPE_NOT_FOUND)).isEqualTo(1)
+    }
+
+    @Test
+    fun `preload safely handles, and reports on, invalid data`(): Unit = runBlocking {
+        val badType = SimpleDataV2::class.qualifiedName.toString()
+        dao.set(VesselEntity(badType, "I'm not JSON"))
+
+        vesselWrapper.set(firstSimple)
+
+        vesselWrapper.get(SimpleData::class)
+
+        val preloadReport = vesselWrapper.preload(1000)
+        val profileData = vesselWrapper.profileData!!
+
+        assertThat(preloadReport.errorsOcurred).isTrue()
+        assertThat(preloadReport.deserializationErrors).isEqualTo(listOf(badType))
+        assertThat(profileData.hitCountOf(Span.WRITE_TO_DB)).isEqualTo(1)
+        assertThat(profileData.hitCountOf(Event.CACHE_HIT_READ)).isEqualTo(1)
+        assertThat(profileData.hitCountOf(Event.DESERIALIZATION_ERROR)).isEqualTo(1)
+    }
+
+    @Test
+    fun `fetching an unknown type is tracked by the profiler`() = runBlocking {
+        val anonymous = object{}
+
+        vesselWrapper.get(anonymous.javaClass.kotlin)
+
+        val profData = vessel.profileData!!
+        assertThat(profData.hitCountOf(Event.TYPE_NOT_FOUND)).isEqualTo(1)
+    }
+
+    @Test
+    fun `fetching invalid data is tracked by the profiler`() = runBlocking {
+        val badType = SimpleData::class.qualifiedName.toString()
+        dao.set(VesselEntity(badType, "I'm not JSON"))
+
+        try {
+            vesselWrapper.get(SimpleData::class)
+        } catch (error: Exception) {
+            Unit
+        }
+
+        val profData = vessel.profileData!!
+
+        assertThat(profData.hitCountOf(Event.DESERIALIZATION_ERROR)).isEqualTo(1)
+    }
+
+    }
+
+
+@Config(sdk = [Build.VERSION_CODES.P])
+@RunWith(AndroidJUnit4::class)
+class SyncErrorHandlingTest : ErrorHandlingTest(false)
+
+@Config(sdk = [Build.VERSION_CODES.P])
+@RunWith(AndroidJUnit4::class)
+class AsncErrorHandling : ErrorHandlingTest(true)

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/PreloadTimeoutTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/PreloadTimeoutTest.kt
@@ -28,8 +28,10 @@ import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import assertk.assertions.isLessThan
 import assertk.assertions.isSuccess
+import assertk.assertions.isTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
@@ -59,9 +61,9 @@ class SlowCache(val insertDelayMS: Long) : DefaultCache() {
 /**
  * Ensure preload timeouts work as expected, and that the resulting data is still usable and correct
  */
-abstract class BasePreloadTest(private val async: Boolean): BaseVesselTest<VesselCache>(DefaultCache(), true, false) {
+abstract class BasePreloadTimeoutTest(private val async: Boolean): BaseVesselTest<VesselCache>(DefaultCache(), true, false) {
     private val slowCache = SlowCache(100)
-    private val slowVessel by lazy{VesselWrapper(get<Vessel>{parametersOf(slowCache, true, false)}, async)}
+    private val slowVessel by lazy{VesselWrapper(get<Vessel>{parametersOf(slowCache, true, false, null)}, async)}
 
     @Test
     fun `preload allows null timeout`(): Unit = runBlocking {
@@ -79,7 +81,7 @@ abstract class BasePreloadTest(private val async: Boolean): BaseVesselTest<Vesse
 
         // 2 entries to preload -> 2x cache insert time
         // Set timeout to << insert time
-        slowVessel.preload(slowCache.insertDelayMS.toInt() / numberOfEntries)
+        val preloadReport = slowVessel.preload(slowCache.insertDelayMS.toInt() / numberOfEntries)
 
         // Only one entry should load into cache before timeout is hit
         assertThat(slowCache.setCount).isEqualTo(1)
@@ -90,18 +92,19 @@ abstract class BasePreloadTest(private val async: Boolean): BaseVesselTest<Vesse
         // Will go to disk
         val data1v2 = slowVessel.get(SimpleDataV2::class)
 
-        val profileData = slowVessel.profileData
+        val profileData = slowVessel.profileData!!
 
         // Timeout should be hit
-        assertThat(profileData?.hitCountOf(Event.PRELOAD_TIMEOUT)).isEqualTo(1)
+        assertThat(preloadReport.timedOut).isTrue()
+        assertThat(profileData.hitCountOf(Event.PRELOAD_TIMEOUT)).isEqualTo(1)
         // Cache hit
-        assertThat(profileData?.hitCountOf(Event.CACHE_HIT_READ)).isEqualTo(1)
+        assertThat(profileData.hitCountOf(Event.CACHE_HIT_READ)).isEqualTo(1)
         // Go to disk
-        assertThat(profileData?.hitCountOf(Span.READ_FROM_DB)).isEqualTo(1)
+        assertThat(profileData.hitCountOf(Span.READ_FROM_DB)).isEqualTo(1)
         // Second disk read cached
         assertThat(slowCache.setCount).isEqualTo(2)
         // Timeout was hit in a sane amount of time
-        assertThat(profileData?.timeIn(Span.PRELOAD_FROM_DB)!!).isLessThan(slowCache.insertDelayMS*numberOfEntries)
+        assertThat(profileData.timeIn(Span.PRELOAD_FROM_DB)).isLessThan(slowCache.insertDelayMS*numberOfEntries)
 
         // Sanity
         assertThat(data1).isEqualTo(firstSimple)
@@ -117,7 +120,7 @@ abstract class BasePreloadTest(private val async: Boolean): BaseVesselTest<Vesse
 
         // 2 entries to prelaod -> 2x cache insertion time
         // Set timeout to >> insertion time
-        slowVessel.preload(slowCache.insertDelayMS.toInt()*numberOfEntries*2)
+        val preloadReport = slowVessel.preload(slowCache.insertDelayMS.toInt()*numberOfEntries*2)
 
         // Both entries should be cached
         assertThat(slowCache.setCount).isEqualTo(2)
@@ -126,27 +129,27 @@ abstract class BasePreloadTest(private val async: Boolean): BaseVesselTest<Vesse
         val data1 = slowVessel.get(SimpleData::class)
         val data1v2 = slowVessel.get(SimpleDataV2::class)
 
-        val profileData = slowVessel.profileData
+        val profileData = slowVessel.profileData!!
 
         // Timeout should not be hit
-        assertThat(profileData?.hitCountOf(Event.PRELOAD_TIMEOUT)).isEqualTo(0)
+        assertThat(preloadReport.timedOut).isFalse()
+        assertThat(profileData.hitCountOf(Event.PRELOAD_TIMEOUT)).isEqualTo(0)
         // Cache hit both reads
-        assertThat(profileData?.hitCountOf(Event.CACHE_HIT_READ)).isEqualTo(2)
+        assertThat(profileData.hitCountOf(Event.CACHE_HIT_READ)).isEqualTo(2)
         // Does not go to disk
-        assertThat(profileData?.hitCountOf(Span.READ_FROM_DB)).isEqualTo(0)
+        assertThat(profileData.hitCountOf(Span.READ_FROM_DB)).isEqualTo(0)
 
         // Sanity
         assertThat(data1).isEqualTo(firstSimple)
         assertThat(data1v2).isEqualTo(firstSimpleV2)
     }
-
 }
 
 
 @Config(sdk = [Build.VERSION_CODES.P])
 @RunWith(AndroidJUnit4::class)
-class SyncPreloadTest: BasePreloadTest(false)
+class SyncPreloadTimeoutTest: BasePreloadTimeoutTest(false)
 
 @Config(sdk = [Build.VERSION_CODES.P])
 @RunWith(AndroidJUnit4::class)
-class AsyncPreloadTest: BasePreloadTest(true)
+class AsyncPreloadTimeoutTest: BasePreloadTimeoutTest(true)

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/PreloadTimeoutTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/PreloadTimeoutTest.kt
@@ -1,5 +1,3 @@
-package com.textnow.android.vessel
-
 /**
  * MIT License
  *
@@ -23,6 +21,8 @@ package com.textnow.android.vessel
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+package com.textnow.android.vessel
 
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/ProfilerTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/ProfilerTest.kt
@@ -1,5 +1,3 @@
-package com.textnow.android.vessel
-
 /**
  * MIT License
  *
@@ -23,6 +21,8 @@ package com.textnow.android.vessel
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+package com.textnow.android.vessel
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselCacheTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselCacheTest.kt
@@ -1,3 +1,27 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020 TextNow, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.textnow.android.vessel
 
 import assertk.assertThat

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselCacheUsageTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselCacheUsageTest.kt
@@ -1,5 +1,3 @@
-package com.textnow.android.vessel
-
 /**
  * MIT License
  *
@@ -23,6 +21,8 @@ package com.textnow.android.vessel
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+package com.textnow.android.vessel
 
 import android.os.Build
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselCacheUsageTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselCacheUsageTest.kt
@@ -163,6 +163,7 @@ abstract class BaseVesselCacheUsageTest(async: Boolean) : BaseVesselTest<TestCac
         assertThat(profData?.hitCountOf(Span.DELETE_FROM_DB)).isEqualTo(1)
         assertThat(profData?.hitCountOf(Event.CACHE_HIT_READ)).isEqualTo(2)
     }
+
 }
 
 @Config(sdk = [Build.VERSION_CODES.P])

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselImplTest.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselImplTest.kt
@@ -28,11 +28,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFailure
+import assertk.assertions.isFalse
 import assertk.assertions.isNull
 import com.textnow.android.vessel.model.*
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.koin.test.get
 import org.robolectric.annotation.Config
 
 /**
@@ -161,6 +163,12 @@ abstract class VesselImplTest(cache: VesselCache?): BaseVesselTest<VesselCache>(
         assertThat(vessel.get(SimpleData::class)).isNull()
         assertThat(vessel.get(MappedData::class)).isNull()
         assertThat(vessel.get(NestedData::class)).isNull()
+    }
+
+    @Test
+    fun `profileData is null when profiling is disabled`() {
+        assertThat(profile).isFalse()
+        assertThat(vessel.profileData).isNull()
     }
 }
 

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselWrapper.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselWrapper.kt
@@ -31,7 +31,7 @@ import kotlin.reflect.KClass
  * code to test the blocking and suspend functions
  */
 class VesselWrapper(private val vessel: Vessel, private val async: Boolean = false) {
-    suspend fun <T: Any> get(type: KClass<T>): T? {
+    suspend fun <T : Any> get(type: KClass<T>): T? {
         return if (async) {
             vessel.get(type)
         } else {
@@ -47,7 +47,7 @@ class VesselWrapper(private val vessel: Vessel, private val async: Boolean = fal
         }
     }
 
-    suspend fun <T: Any> delete(type: KClass<T>) {
+    suspend fun <T : Any> delete(type: KClass<T>) {
         if (async) {
             vessel.delete(type)
         } else {
@@ -55,12 +55,10 @@ class VesselWrapper(private val vessel: Vessel, private val async: Boolean = fal
         }
     }
 
-    suspend fun preload(timeoutMS: Int?): PreloadReport {
-        if (async) {
-            return vessel.preload(timeoutMS)
-        } else {
-            return vessel.preloadBlocking(timeoutMS)
-        }
+    suspend fun preload(timeoutMS: Int?) = if (async) {
+        vessel.preload(timeoutMS)
+    } else {
+        vessel.preloadBlocking(timeoutMS)
     }
 
     val profileData get() = vessel.profileData

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselWrapper.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselWrapper.kt
@@ -31,11 +31,11 @@ class VesselWrapper(private val vessel: Vessel, private val async: Boolean = fal
         }
     }
 
-    suspend fun preload(timeoutMS: Int?) {
+    suspend fun preload(timeoutMS: Int?): PreloadReport {
         if (async) {
-            vessel.preload(timeoutMS)
+            return vessel.preload(timeoutMS)
         } else {
-            vessel.preloadBlocking(timeoutMS)
+            return vessel.preloadBlocking(timeoutMS)
         }
     }
 

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselWrapper.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/VesselWrapper.kt
@@ -1,3 +1,27 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020 TextNow, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.textnow.android.vessel
 
 import kotlin.reflect.KClass

--- a/vessel-runtime/src/test/java/com/textnow/android/vessel/di/TestModule.kt
+++ b/vessel-runtime/src/test/java/com/textnow/android/vessel/di/TestModule.kt
@@ -30,8 +30,8 @@ import org.koin.dsl.module
  * Koin module to be reset during each @Test.
  */
 val testModule = module {
-    factory<Vessel> {
-        (cache: VesselCache?, profile: Boolean?, inMemory: Boolean?) -> VesselImpl(
+    factory<Vessel> { (cache: VesselCache?, profile: Boolean?, inMemory: Boolean?, db: VesselDb) ->
+        VesselImpl(
             appContext = get(),
             inMemory = inMemory ?: true,
             allowMainThread = true,
@@ -42,7 +42,8 @@ val testModule = module {
                 onDestructiveMigration = { println("Destructive migration") }
             ),
             cache = cache,
-            profile = profile ?: false
+            profile = profile ?: false,
+            externalDb = db
         )
     }
 }


### PR DESCRIPTION
An instance of a type stored in Vessel may be un-serializable when
the definition of that type changes.

This can occur when a type's definition is changed but an instance
of that type stored in Vessel is not removed or migrated.

The `preload()` and `preloadBlocking()` APIs can now recover from this state
and continue to preload any remaining valid data.

`preload()`/`prealoadBlocking()` now return the result of the preload operation -
which errors ocurred (if any), and if the preload timeout was hit.

Since this is an API change, this is also a breaking change.

For completeness this same reporting has been added to the profiling data.

Also fixing issue #36