### PR TITLE
fix dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+-   Updated dokka dependencies to the first version that doesn't depend on `jcenter`
+-   Removed references to `jcenter` from our own repository lists
+
+### Changed
 -   Update dokka and github actions to compile correctly
 
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ buildscript {
         mavenLocal()
         mavenCentral()
         google()
-        jcenter()
     }
 
     dependencies {
@@ -25,7 +24,6 @@ allprojects {
         mavenLocal()
         mavenCentral()
         google()
-        jcenter()
     }
 
     tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 buildscript {
     repositories {
         mavenLocal()
+        mavenCentral()
         google()
         jcenter()
     }
@@ -22,6 +23,7 @@ plugins {
 allprojects {
     repositories {
         mavenLocal()
+        mavenCentral()
         google()
         jcenter()
     }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -24,7 +24,7 @@
 object Versions {
     const val kotlin = "1.5.21"
     const val androidGradle = "7.0.2"
-    const val dokka = "1.4.30"
+    const val dokka = "1.4.32"
     const val kover = "0.5.0"
     const val intellijCover = "1.0.656"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,5 @@ include(":vessel-runtime")
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        jcenter()
     }
 }


### PR DESCRIPTION
- Updated to the first version of dokka that doesn't use jcenter.
- Added mavenCentral to our repo list
- Removed jcenter from our own repositories list. 

This should (🤞) let our publish action work.